### PR TITLE
jshashes version

### DIFF
--- a/js/lib/mediawiki.ApiRequest.js
+++ b/js/lib/mediawiki.ApiRequest.js
@@ -1,5 +1,23 @@
 "use strict";
 
+function GUID ()
+{
+    var S4 = function ()
+    {
+        return Math.floor(
+                Math.random() * 0x10000 /* 65536 */
+            ).toString(16);
+    };
+
+    return (
+            S4() + S4() + "-" +
+            S4() + "-" +
+            S4() + "-" +
+            S4() + "-" +
+            S4() + S4() + S4()
+        );
+}
+
 var request = require('request'),
 	$ = require( 'jquery' ),
 	qs = require('querystring'),
@@ -37,6 +55,7 @@ function TemplateRequest ( env, title, oldid ) {
 	if ( env.syncval ) {
 		apiargs.syncval = env.syncval;
 	}
+	apiargs.cb = GUID();
 	if ( oldid ) {
 		apiargs.revids = oldid;
 		delete apiargs.titles;
@@ -120,6 +139,7 @@ TemplateRequest.prototype._handler = function (error, response, body) {
         		if ( env.syncval ) {
                 		apiargs.syncval = env.syncval;
         		}
+			apiargs.cb = GUID();
 			var url = this.env.wgScript + '/api' +
 				this.env.wgScriptExtension +
 				'?' +

--- a/js/lib/mediawiki.ApiRequest.js
+++ b/js/lib/mediawiki.ApiRequest.js
@@ -34,6 +34,9 @@ function TemplateRequest ( env, title, oldid ) {
 		rvprop: 'content',
 		titles: title
 	};
+	if ( env.syncval ) {
+		apiargs.syncval = env.syncval;
+	}
 	if ( oldid ) {
 		apiargs.revids = oldid;
 		delete apiargs.titles;
@@ -107,16 +110,20 @@ TemplateRequest.prototype._handler = function (error, response, body) {
 		var redirMatch = src.match( /[\r\n\s]*#\s*redirect\s*\[\[([^\]]+)\]\]/i );
 		if ( redirMatch ) {
 			var title = redirMatch[1],
-				url = this.env.wgScript + '/api' +
+				apiargs = {
+					format: 'json',
+					action: 'query',
+					prop: 'revisions',
+					rvprop: 'content',
+					titles: title
+				};			
+        		if ( env.syncval ) {
+                		apiargs.syncval = env.syncval;
+        		}
+			var url = this.env.wgScript + '/api' +
 				this.env.wgScriptExtension +
 				'?' +
-				qs.stringify( {
-					format: 'json',
-				action: 'query',
-				prop: 'revisions',
-				rvprop: 'content',
-				titles: title
-				} );
+				qs.stringify( apiargs );
 			//'?format=json&action=query&prop=revisions&rvprop=content&titles=' + title;
 			this.requestOptions.url = url;
 			request( this.requestOptions, this._handler.bind(this) );

--- a/js/package.json
+++ b/js/package.json
@@ -8,7 +8,7 @@
 		"request": "2.x.x",
 		"querystring": "0.x.x",
 		"path": "0.x.x",
-		"jshashes": "0.x.x",
+		"jshashes": "1.x.x",
 		"optimist": "0.x.x",
 		"assert": "0.x.x",
 		"jsdom": "0.x.x",


### PR DESCRIPTION
<code>
npm ERR! Error: No compatible version found: jshashes@'>=0.0.0- <1.0.0-'
npm ERR! Valid install targets:
npm ERR! ["1.0.2","1.0.3"]
npm ERR!     at installTargetsError (/usr/lib/nodejs/npm/lib/cache.js:674:10)
npm ERR!     at next (/usr/lib/nodejs/npm/lib/cache.js:653:17)
npm ERR!     at /usr/lib/nodejs/npm/lib/cache.js:633:5
npm ERR!     at saved (/usr/lib/nodejs/npm/node_modules/npm-registry-client/lib/get.js:138:7)
npm ERR!     at /usr/lib/nodejs/npm/node_modules/graceful-fs/graceful-fs.js:218:7
npm ERR!     at Object.oncomplete (fs.js:297:15)
npm ERR! If you need help, you may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     npm-@googlegroups.com
</code>

jshashes is only now available in version "1.0.2" and "1.0.3".
