### PR TITLE
Make Parsoid give us data that item is a video

### DIFF
--- a/js/lib/ext.core.LinkHandler.js
+++ b/js/lib/ext.core.LinkHandler.js
@@ -849,8 +849,7 @@ WikiLinkHandler.prototype.renderFile = function (token, frame, cb, target)
 			return;
 		}
 		var	dims, image, info, containerName, container, containerClose,
-			dataAttribs,
-			rdfaType = 'mw:Image',
+			dataAttribs, rdfaType,
 			iContainerName = hasImageLink ? 'a' : 'span',
 			ns = data.imgns,
 			innerContain = new TagTk( iContainerName, [] ),
@@ -973,6 +972,16 @@ WikiLinkHandler.prototype.renderFile = function (token, frame, cb, target)
 			if ( caption !== undefined ) {
 				caption = closeUnclosedBlockTags( caption );
 			}
+		}
+
+		// Determine rdfaType
+		switch ( info.mediatype ) {
+			case 'VIDEO':
+				rdfaType = 'mw:Video';
+				break;
+			default:
+				rdfaType = 'mw:Image';
+				break;
 		}
 
 		// If the format is something we *recognize*, add the subtype

--- a/js/lib/mediawiki.ApiRequest.js
+++ b/js/lib/mediawiki.ApiRequest.js
@@ -685,7 +685,8 @@ function ImageInfoRequest( env, filename, dims ) {
 		imgns = conf.namespaceNames[imgnsid],
 		props = [
 			'size',
-			'url'
+			'url',
+			'mediatype'
 		];
 
 	this.ns = imgns;

--- a/js/lib/mediawiki.WikitextSerializer.js
+++ b/js/lib/mediawiki.WikitextSerializer.js
@@ -1538,16 +1538,19 @@ WSP.handleImage = function ( node, state, cb ) {
 	currentOpt = {};
 	switch ( rel ) {
 		case 'mw:Image/Thumb':
+		case 'mw:Video/Thumb':
 			currentOpt.ck = 'thumbnail';
 			currentOpt.ak = mwAliases.img_thumbnail.last();
 			break;
 
 		case 'mw:Image/Frame':
+		case 'mw:Video/Frame':
 			currentOpt.ck = 'framed';
 			currentOpt.ak = mwAliases.img_framed.last();
 			break;
 
 		case 'mw:Image/Frameless':
+		case 'mw:Video/Frameless':
 			currentOpt.ck = 'frameless';
 			currentOpt.ak = mwAliases.img_frameless.last();
 			break;
@@ -1929,6 +1932,10 @@ WSP.genContentSpanTypes = {
 	'mw:Image/Frameless': 1,
 	'mw:Image/Frame': 1,
 	'mw:Image/Thumb': 1,
+	'mw:Video': 1,
+	'mw:Video/Frameless': 1,
+	'mw:Video/Frame': 1,
+	'mw:Video/Thumb': 1,
 	'mw:Entity': 1,
 	'mw:DiffMarker': 1
 };
@@ -2618,6 +2625,8 @@ WSP.tagHandlers = {
 					}
 					emitEndTag('</nowiki>', node, state, cb);
 				} else if ( type.match( /\bmw\:Image(\/(Frame|Frameless|Thumb))?/ ) ) {
+					state.serializer.handleImage( node, state, cb );
+				} else if ( type.match( /\bmw\:Video(\/(Frame|Frameless|Thumb))?/ ) ) {
 					state.serializer.handleImage( node, state, cb );
 				}
 			} else {

--- a/js/tests/mockAPI.js
+++ b/js/tests/mockAPI.js
@@ -10,13 +10,16 @@ var IMAGE_DESC_URL = IMAGE_BASE_URL;
 //IMAGE_DESC_URL='http://commons.wikimedia.org/wiki';
 var FILE_PROPS = {
 	'Foobar.jpg': {
-		size: 7881, width: 1941, height: 220, bits: 8, mime: 'image/jpeg'
+		size: 7881, width: 1941, height: 220, bits: 8, mime: 'image/jpeg', mediatype: 'BITMAP'
 	},
 	'Thumb.png': {
-		size: 22589, width: 135, height: 135, bits: 8, mime: 'image/png'
+		size: 22589, width: 135, height: 135, bits: 8, mime: 'image/png', mediatype: 'BITMAP'
 	},
 	'Foobar.svg': {
-		size: 12345, width: 240, height: 180, bits: 24, mime: 'image/svg+xml'
+		size: 12345, width: 240, height: 180, bits: 24, mime: 'image/svg+xml', mediatype: 'BITMAP'
+	},
+	'Foobar.mov': {
+		size: 12345, width: 640, height: 480, bits: 8, mime: 'video/quicktime', mediatype: 'VIDEO'
 	}
 };
 
@@ -36,11 +39,14 @@ function sanitizeHTMLAttribute( text ) {
 
 var fnames = {
 		'Image:Foobar.jpg': 'Foobar.jpg',
-		'File:Foobar.jpg': 'Foobar.jpg'
+		'File:Foobar.jpg': 'Foobar.jpg',
+		'Image:Foobar.mov': 'Foobar.mov',
+		'File:Foobar.mov': 'Foobar.mov'
 	},
 
 	pnames = {
-		'Image:Foobar.jpg': 'File:Foobar.jpg'
+		'Image:Foobar.jpg': 'File:Foobar.jpg',
+		'Image:Foobar.mov': 'File:Foobar.mov'
 	},
 
 	formatters = {
@@ -107,7 +113,8 @@ var fnames = {
 						height: height,
 						width: width,
 						url: baseurl,
-						descriptionurl: durl
+						descriptionurl: durl,
+						mediatype: props.mediatype
 					} ]
 				},
 				response = {

--- a/js/tests/parserTests.txt
+++ b/js/tests/parserTests.txt
@@ -154,7 +154,6 @@ Blank input
 !! result
 !! end
 
-
 !! test
 Simple paragraph
 !! input
@@ -9510,6 +9509,30 @@ parsoid
 #</span>
 #</p>
 
+###
+### Videos
+###
+
+!! test
+Inline video
+!! options
+parsoid
+!! input
+[[File:Foobar.mov]]
+!! result
+<p><span class="mw-default-size" typeof="mw:Video"><a href="File:Foobar.mov"><img resource="./File:Foobar.mov" src="//example.com/images/a/a3/Foobar.mov" height="480" width="640"></a></span>
+</p>
+!! end
+
+!! test
+Block video
+!! options
+parsoid
+!! input
+[[File:Foobar.mov|thumb]]
+!! result
+<figure class="mw-default-size" typeof="mw:Video/Thumb"><a href="File:Foobar.mov"><img resource="./File:Foobar.mov" src="//example.com/images/a/a3/Foobar.mov" height="135" width="180"></a></figure>
+!! end
 
 ###
 ### Subpages


### PR DESCRIPTION
Parsoid requests mediatype as a parameter in the mediawiki api request. In LinkHandler, rdfaType is declared as a variable but not given a value until the switch statement that checks the mediatype returned from the api. 
