### PR TITLE
Proper fix for img_class (tests are still passing and it fallbacks nicel...

### DIFF
--- a/js/lib/mediawiki.WikiConfig.js
+++ b/js/lib/mediawiki.WikiConfig.js
@@ -396,7 +396,7 @@ WikiConfig.prototype.getMagicPatternMatcher = function ( optionsList ) {
 		if ( ix > 0 ) {
 			regexString += '|';
 		}
-		aliases = this._interpolatedMagicWordAliases[optionsList[ix]];
+		aliases = this._interpolatedMagicWordAliases[optionsList[ix]] || [];
 		regexString += aliases.join( '|' )
 			.replace( /((?:^|\|)(?:[^\$]|\$[^1])*)($|\|)/g, '$1$$1$2' )
 			.replace( /\$1/g, '(.*)' );

--- a/js/lib/mediawiki.wikitext.constants.js
+++ b/js/lib/mediawiki.wikitext.constants.js
@@ -25,9 +25,7 @@ var WikitextConstants = {
 			'img_page'      : 'page',
 			'img_upright'   : 'upright',
 			'img_width'     : 'width',
-			// Wikia backwards compatibility fix #back-compat
-			// MW 1.19 doesn't support this magicword
-			//'img_class'     : 'class',
+			'img_class'     : 'class',
 			'img_manualthumb': 'manualthumb'
 		}),
 		/* filled in below, based on PrefixOptions */


### PR DESCRIPTION
...y in case of old MW api)
