### PR TITLE
VE-541 Modify how Parsoid handles the API calls

### DIFF
--- a/js/api/ParserService.js
+++ b/js/api/ParserService.js
@@ -686,9 +686,10 @@ function wt2html( req, res, wt ) {
 	}
 }
 
-// TODO: Ken
+// pattern for all routes that do not begin with _
+var patternForApiUriOrPrefix = '^[^_](.+)/(.*)';
 // Regular article parsing
-app.get( new RegExp( '^[^_](.+)/(.*)' ), interParams, parserEnvMw, function(req, res) {
+app.get( new RegExp( patternForApiUriOrPrefix ), interParams, parserEnvMw, function(req, res) {
 	var env = res.locals.env;
 
 	// TODO gwicke: re-enable this when actually using Varnish
@@ -701,9 +702,8 @@ app.get( new RegExp( '^[^_](.+)/(.*)' ), interParams, parserEnvMw, function(req,
 	wt2html( req, res );
 });
 
-// TODO: Ken
 // Regular article serialization using POST
-app.post( new RegExp( '/(' + getInterwikiRE() + ')/(.*)' ), interParams, parserEnvMw, function ( req, res ) {
+app.post( new RegExp( patternForApiUriOrPrefix ), interParams, parserEnvMw, function ( req, res ) {
 
 	// parse html or wt
 	if ( req.body.wt ) {
@@ -753,110 +753,6 @@ app.get( /\/_ci\/master/, function ( req, res ) {
 		res.end( '' );
 	} );
 } );
-
-// var _config = require('./controllers/config.js');
-// app.get( encodedURIRegex, _config.post);
-// var encodedURIRegex = /(^|\s)\/((https?%3A%2F%2F\S*)?)\/(.*)/gi;
-// var crypto = require( 'crypto' );
-// function Prefixer( str ) {
-// 	this.cache = {};
-// 	this.init( str );
-// }
-// 
-// Prefixer.prototype.init = function( str ) {
-// 	this.prefix = str + '-';
-// };
-// 
-// Prefixer.prototype.set = function( endpoint ) {
-// 	var timestamp = new Date().valueOf().toString();
-// 	var random = Math.random().toString();
-// 
-// 	var id = crypto
-// 		.createHash( 'sha1' )
-// 		.update( timestamp + random )
-// 		.digest( 'hex' );
-// 
-// 	endpoint = decodeURIComponent( endpoint );
-// 
-// 	if ( typeof endpoint === 'string' ) {
-// 		parsoidConfig.setInterwiki( id, endpoint );
-// 		this.cache[ id ] = endpoint;
-// 		return id;
-// 	} else {
-// 		throw 'Not a valid endpoint';
-// 	}
-// };
-// 
-// Prefixer.prototype.get = function( prefix ) {
-// 	return this.cache[ prefix ];
-// };
-// 
-// Prefixer.prototype.delete = function( id ) {
-// 	delete this.cache[ id ];
-// 	delete parsoidConfig[ id ];
-// };
-// 
-// var prefixStore = new Prefixer( 'tmp' );
-// 
-// app.get( encodedURIRegex, function( req, res ) {
-// 	var parts,
-// 			article;
-// 
-// 	parts = req.url.slice( 1 ).split( '/' );
-// 	article = {
-// 		parent: parts[ 1 ],
-// 		child: parts[ 2 ]
-// 	};
-// 
-// 	var prefix = prefixStore.set( parts[ 0 ] );
-// 
-// 	var cb = function ( env ) {
-// 		if ( env.page.name === 'favicon.ico' ) {
-// 			res.send( 'no favicon yet..', 404 );
-// 			return;
-// 		}
-// 
-// 		//console.log(req.headers);
-// 
-// 		var target = env.resolveTitle( env.normalizeTitle( env.page.name ), '' );
-// 
-// 		// Set the timeout to 900 seconds..
-// 		req.connection.setTimeout(900 * 1000);
-// 
-// 		console.log('starting parsing of ' + prefix + ':' + target);
-// 		var oldid = null;
-// 		if ( req.query.oldid && !req.headers.cookie ) {
-// 			oldid = req.query.oldid;
-// 			res.setHeader('Cache-Control', 's-maxage=2592000');
-// 		} else {
-// 			// Don't cache requests with a session or no oldid
-// 			res.setHeader('Cache-Control', 'private,no-cache,s-maxage=0');
-// 		}
-// 		if (env.conf.parsoid.allowCORS) {
-// 			// allow cross-domain requests (CORS) so that parsoid service
-// 			// can be used by third-party sites
-// 			res.setHeader('Access-Control-Allow-Origin',
-// 						  env.conf.parsoid.allowCORS);
-// 		}
-// 
-// 		var tpr = new TemplateRequest( env, target, oldid );
-// 		tpr.once('src', parse.bind( null, env, req, res, function ( req, res, src, doc ) {
-// 			var out = DU.serializeNode(doc.documentElement);
-// 			res.setHeader('X-Parsoid-Performance', env.getPerformanceHeader());
-// 			res.end(out);
-// 			console.warn("completed parsing of " + prefix +
-// 				':' + target + " in " + env.performance.duration + " ms");
-// 		}));
-// 
-// 		prefixStore.delete( prefix );
-// 	};
-// 
-// 	console.log(parsoidConfig.interwikiMap);
-// 
-// 	// var prefix = req.params[0];
-// 	getParserServiceEnv( res, prefix, article.parent, cb, req );
-// 
-// });
 
 app.use( express.static( __dirname + '/scripts' ) );
 app.use( express.limit( '15mb' ) );

--- a/js/lib/mediawiki.parser.environment.js
+++ b/js/lib/mediawiki.parser.environment.js
@@ -304,9 +304,9 @@ MWParserEnvironment.prototype.getPerformanceHeader = function () {
 };
 
 MWParserEnvironment.prototype.isApiSourceAUri = function( apiSource ) {
-	var uriPattern = /^https?%3A%2F%2F(.*)/gi;
-	apiSource = encodeURIComponent( apiSource );
-	return !apiSource.match( uriPattern ) ? false : true;
+	var uriPattern = /^https?:\/\/(.*)/gi;
+	apiSource = apiSource;
+	return !!apiSource.match( uriPattern );
 };
 
 /**

--- a/js/lib/mediawiki.parser.environment.js
+++ b/js/lib/mediawiki.parser.environment.js
@@ -304,9 +304,7 @@ MWParserEnvironment.prototype.getPerformanceHeader = function () {
 };
 
 MWParserEnvironment.prototype.isApiSourceAUri = function( apiSource ) {
-	var uriPattern = /^https?:\/\/(.*)/gi;
-	apiSource = apiSource;
-	return !!apiSource.match( uriPattern );
+	return ( /^https?:\/\/(.*)/gi ).test( apiSource );
 };
 
 /**

--- a/js/lib/mediawiki.parser.environment.js
+++ b/js/lib/mediawiki.parser.environment.js
@@ -263,7 +263,7 @@ MWParserEnvironment.prototype.setVariable = function( varname, value, options ) 
  * @param {Error} cb.err
  * @param {MWParserEnvironment} cb.env The finished environment object
  */
-MWParserEnvironment.getParserEnv = function ( parsoidConfig, wikiConfig, prefix, pageName, cookie, cb ) {
+MWParserEnvironment.getParserEnv = function ( parsoidConfig, wikiConfig, apiSource, pageName, cookie, cb ) {
 	if ( !parsoidConfig ) {
 		parsoidConfig = new ParsoidConfig();
 		parsoidConfig.setInterwiki( 'mw', 'http://www.mediawiki.org/w/api.php' );
@@ -281,7 +281,7 @@ MWParserEnvironment.getParserEnv = function ( parsoidConfig, wikiConfig, prefix,
 	}
 
 	// Get that wiki's config
-	env.switchToConfig( prefix, function ( err ) {
+	env.switchToConfig( apiSource, function ( err ) {
 		cb( err, env );
 	} );
 };
@@ -303,6 +303,12 @@ MWParserEnvironment.prototype.getPerformanceHeader = function () {
 	} ).join( '; ' );
 };
 
+MWParserEnvironment.prototype.isApiSourceAUri = function( apiSource ) {
+	var uriPattern = /^https?%3A%2F%2F(.*)/gi;
+	apiSource = encodeURIComponent( apiSource );
+	return !apiSource.match( uriPattern ) ? false : true;
+};
+
 /**
  * Function that switches to a different configuration for a different wiki.
  * Caches all configs so we only need to get each one once (if we do it right)
@@ -311,46 +317,54 @@ MWParserEnvironment.prototype.getPerformanceHeader = function () {
  * @param {Function} cb
  * @param {Error} cb.err
  */
-MWParserEnvironment.prototype.switchToConfig = function ( prefix, cb ) {
+MWParserEnvironment.prototype.switchToConfig = function ( apiSource, cb ) {
+	var isUri = this.isApiSourceAUri( apiSource );
 
 	function setupWikiConfig(env, apiURI, error, config) {
 		if ( error === null ) {
-			env.conf.wiki = new WikiConfig( config, prefix, apiURI );
-			env.confCache[prefix] = env.conf.wiki;
+			env.conf.wiki = new WikiConfig( config, apiSource, apiURI );
+			env.confCache[apiSource] = env.conf.wiki;
 		}
 
 		cb( error );
 	}
 
-	if (!prefix) {
-		console.error("ERROR: No prefix provided!");
-		cb(new Error("Wiki prefix not provided"));
+	if (!apiSource) {
+		console.error("ERROR: No valid prefix or API URI provided!");
+		cb(new Error("Wiki prefix or API URI not provided"));
 		return;
 	}
 
-	var uri = this.conf.parsoid.interwikiMap[prefix];
-	if (!uri) {
-		// SSS: Ugh! Looks like parser tests use a prefix
-		// that is not part of the interwikiMap -- so we
-		// cannot crash with an error.  Hence defaulting
-		// to enwiki api which is quite odd.  Does the
-		// interwikiMap need updating or is this use-case
-		// valid outside of parserTests??
-		console.error("ERROR: Did not find api uri for " + prefix + "; defaulting to en");
-		uri = this.conf.parsoid.interwikiMap.en;
+	var uri;
+
+	if ( isUri ) {
+		uri = apiSource;
+	} else {
+		uri = this.conf.parsoid.interwikiMap[ apiSource ];
+
+		if (!uri) {
+			// SSS: Ugh! Looks like parser tests use a prefix
+			// that is not part of the interwikiMap -- so we
+			// cannot crash with an error.  Hence defaulting
+			// to enwiki api which is quite odd.  Does the
+			// interwikiMap need updating or is this use-case
+			// valid outside of parserTests??
+			console.error("ERROR: Did not find api uri for " + apiSource + "; defaulting to en");
+			uri = this.conf.parsoid.interwikiMap.en;
+		}
 	}
 
 	this.conf.parsoid.apiURI = uri;
 
-	if ( this.confCache[prefix] ) {
-		this.conf.wiki = this.confCache[prefix];
+	if ( this.confCache[ apiSource ] ) {
+		this.conf.wiki = this.confCache[ apiSource ];
 		cb( null );
-	} else if ( this.conf.parsoid.fetchConfig ) {
+	} else if ( this.conf.parsoid.fetchConfig || isUri ) {
 		var confRequest = new ConfigRequest( uri, this );
 		confRequest.on( 'src', setupWikiConfig.bind(null, this, uri));
 	} else {
 		// Load the config from cached config on disk
-		var localConfigFile = './baseconfig/' + prefix + '.json',
+		var localConfigFile = './baseconfig/' + apiSource + '.json',
 			localConfig = require(localConfigFile);
 
 		if (localConfig && localConfig.query) {


### PR DESCRIPTION
## Overview

The scope of this PR includes modifying `ParserService.js` and `mediawiki.parser.environment.js` to accept URIs for api configs in addition to the current functionality of being able to pass a canonical `prefix`. To accomplish this, modifications have been made in:
- [`MWParserEnvironment.getParserEnv`](https://github.com/Wikia/mediawiki-extensions-Parsoid/compare/master...ve-541-parsoid-custom-config?expand=1#diff-3a649c2384d417c3c5ae4ebad7ee6404L266)
- [`MWParserEnvironment.prototype.switchToConfig`](https://github.com/Wikia/mediawiki-extensions-Parsoid/compare/master...ve-541-parsoid-custom-config?expand=1#diff-3a649c2384d417c3c5ae4ebad7ee6404L314)

In addition, a simple helper method to match URIs was added to `MWParserEnvironment`: [`MWParserEnvironment.prototype.isApiSourceAUri`](https://github.com/Wikia/mediawiki-extensions-Parsoid/compare/master...ve-541-parsoid-custom-config?expand=1#diff-3a649c2384d417c3c5ae4ebad7ee6404L305)

The regex for affected routes and variables previously named `prefix` have been generalized to reflect to wider range of accepted inputs.
### Todo
- [x] Update regex for routes
- [x] Update tests (if applicable)

@inez @kflorence @BladeBronson @lizlux 
