### PR TITLE
For consistency with MediaWiki, rename all references to type 'photo' to 'image'

### DIFF
--- a/js/lib/ext.core.LinkHandler.js
+++ b/js/lib/ext.core.LinkHandler.js
@@ -24,7 +24,7 @@ var KV = defines.KV,
     SelfclosingTagTk = defines.SelfclosingTagTk,
     EndTagTk = defines.EndTagTk,
 	ImageInfoRequest = require( './mediawiki.ApiRequest.js' ).ImageInfoRequest,
-	PhotoAttributionRequest = require( './mediawiki.ApiRequest.js' ).PhotoAttributionRequest;
+	ImageAttributionRequest = require( './mediawiki.ApiRequest.js' ).ImageAttributionRequest;
 
 function WikiLinkHandler( manager, options ) {
 	this.manager = manager;
@@ -1185,11 +1185,11 @@ WikiLinkHandler.prototype.renderFile = function (token, frame, cb, target)
 		}
 	}
 	var imageInfoRequest = new ImageInfoRequest( env, filename, constraints ),
-		photoAttributionRequest = new PhotoAttributionRequest( env, filename );
+		imageAttributionRequest = new ImageAttributionRequest( env, filename );
 
 	asyncLib.parallel( [
 		imageInfoRequest.once.bind( imageInfoRequest, 'src' ),
-		photoAttributionRequest.once.bind( photoAttributionRequest, 'src' )
+		imageAttributionRequest.once.bind( imageAttributionRequest, 'src' )
 	],  handleResponse.bind( null, linkTitle ) );
 
 	/*

--- a/js/lib/mediawiki.ApiRequest.js
+++ b/js/lib/mediawiki.ApiRequest.js
@@ -796,7 +796,7 @@ ImageInfoRequest.prototype._handleJSON = function ( error, data ) {
  * @param {MWParserEnvironment} env
  * @param {string} filename
  */
-function PhotoAttributionRequest( env, filename ) {
+function ImageAttributionRequest( env, filename ) {
 	ApiRequest.call( this, env, null );
 	this.env = env;
 
@@ -804,7 +804,7 @@ function PhotoAttributionRequest( env, filename ) {
 		url = conf.apiURI + '?';
 
 	var apiArgs = {
-		action: 'apiphotoattribution',
+		action: 'apiimageattribution',
 		format: 'json',
 		file: filename
 	};
@@ -825,12 +825,12 @@ function PhotoAttributionRequest( env, filename ) {
 	this.request( this.requestOptions, this._requestCB.bind( this ) );
 }
 
-util.inherits( PhotoAttributionRequest, ApiRequest );
+util.inherits( ImageAttributionRequest, ApiRequest );
 
 /**
  * @inheritdoc ApiRequest#_handleJSON
  */
-PhotoAttributionRequest.prototype._handleJSON = function ( error, data ) {
+ImageAttributionRequest.prototype._handleJSON = function ( error, data ) {
 	var pagenames, names, namelist, newpages, pages, pagelist, ix;
 
 	if ( error ) {
@@ -859,7 +859,7 @@ if (typeof module === "object") {
 	module.exports.PHPParseRequest = PHPParseRequest;
 	module.exports.ParsoidCacheRequest = ParsoidCacheRequest;
 	module.exports.ImageInfoRequest = ImageInfoRequest;
-	module.exports.PhotoAttributionRequest = PhotoAttributionRequest;
+	module.exports.ImageAttributionRequest = ImageAttributionRequest;
 	module.exports.DoesNotExistError = DoesNotExistError;
 	module.exports.ParserError = ParserError;
 }

--- a/js/tests/mockAPI.js
+++ b/js/tests/mockAPI.js
@@ -162,7 +162,7 @@ var fnames = {
 			response.query.pages['1'] = imageinfo;
 			cb( null, response );
 		},
-		apiphotoattribution: function ( body, cb ) {
+		apiimageattribution: function ( body, cb ) {
 			cb( null, {
 				'username': 'Foo',
 				'avatar': 'Foo.png'


### PR DESCRIPTION
**DO NOT MERGE YET** breaks production parsoid
