### PR TITLE
If "oldwt" parameter is passed in serializing POST request it then use i...

### DIFF
--- a/js/api/ParserService.js
+++ b/js/api/ParserService.js
@@ -573,7 +573,12 @@ app.post(/\/_rtform\/(.*)/, defaultParams, parserEnvMw, function ( req, res ) {
 
 function html2wt( req, res, html ) {
 	var env = res.locals.env;
-	env.page.id = req.body.oldid || null;
+	if ( req.body.oldwt ) {
+		env.setPageSrcInfo( req.body.oldwt );
+		env.page.id = null;
+	} else {
+		env.page.id = req.body.oldid || null;
+	}
 
 	var doc;
 	try {


### PR DESCRIPTION
...t as a original wikitext instead of pulling it from database based on oldid
