### PR TITLE
VE-572 VE: Parsoid is throwing 404 errors on multiple wikis

### DIFF
--- a/js/api/ParserService.js
+++ b/js/api/ParserService.js
@@ -687,7 +687,7 @@ function wt2html( req, res, wt ) {
 }
 
 // pattern for all routes that do not begin with _
-var patternForApiUriOrPrefix = '^[^\/?_](.+)/(.*)';
+var patternForApiUriOrPrefix = '^[/_](.*)/(.*)';
 // Regular article parsing
 app.get( new RegExp( patternForApiUriOrPrefix ), interParams, parserEnvMw, function(req, res) {
 	var env = res.locals.env;

--- a/js/api/ParserService.js
+++ b/js/api/ParserService.js
@@ -687,7 +687,7 @@ function wt2html( req, res, wt ) {
 }
 
 // pattern for all routes that do not begin with _
-var patternForApiUriOrPrefix = '^[/_](.*)/(.*)';
+var patternForApiUriOrPrefix = '^[/_](.+)/(.*)';
 // Regular article parsing
 app.get( new RegExp( patternForApiUriOrPrefix ), interParams, parserEnvMw, function(req, res) {
 	var env = res.locals.env;


### PR DESCRIPTION
**Ignore this PR.** Real one is here: https://github.com/Wikia/mediawiki-extensions-Parsoid/pull/18

Original regex bug fix was incorrect. This has been fixed and should handle prefixes, api endpoints and routes that start with `_`.

@inez @kflorence 
