### PR TITLE
VE-601: Tolerate interwikis without placeholder

### DIFF
--- a/js/lib/mediawiki.WikiConfig.js
+++ b/js/lib/mediawiki.WikiConfig.js
@@ -118,6 +118,13 @@ function WikiConfig( resultConf, prefix, uri ) {
 	for ( var index = 0; index < interwikiKeys.length; index++ ) {
 		var key = interwikimap[index].prefix;
 		this.interwikiMap[key] = interwikimap[index];
+		if (!/$1/.test(this.interwikiMap[key].url)) {
+			// Fix up broken interwiki hrefs that are missing a $1 placeholder
+			// Just append the placeholder at the end.
+			// This makes sure that the InterWikiMatcher below adds one match
+			// group per URI, and that interwiki links work as expected.
+			this.interwikiMap[key].url += '$1';
+		}
 	}
 
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/VE-601

Fixed upstream and patched here: https://gerrit.wikimedia.org/r/#/c/102612/
