### PR TITLE
OPS-4596 - New version of NewRelic Agent 

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -19,7 +19,7 @@
 		"html5-entities": "~0.5.0",
 		"html5": "0.3.15",
 		"es6-shim": "git+https://github.com/paulmillr/es6-shim#7dc668687c3a89ed9e7b6d6c6369f0ba8ebf8731",
-		"newrelic": "~1.1.1"
+		"newrelic": "~1.5.0"
 	},
 	"devDependencies": {
 		"colors": "0.x.x",


### PR DESCRIPTION
Reason for upgrade:

```
The Node.js application Parsoid is using an out-of-date agent. We recommend 1.2.0 and up.
```
